### PR TITLE
Implement functional agents and tool infrastructure

### DIFF
--- a/blink-note-obsidian/src/agents/ExecutorAgent.ts
+++ b/blink-note-obsidian/src/agents/ExecutorAgent.ts
@@ -1,9 +1,64 @@
 // src/agents/ExecutorAgent.ts
 
+import { eventBus, EventBus } from '../services/EventBus';
+import { SessionMemory } from '../services/SessionMemory';
+import { AuditLogService } from '../services/AuditLogService';
+import { ExecutionPlan, ExecutionStep } from '../types';
+import { IAgent } from '../types/Agent';
+import { ToolRegistry } from '../tools/ToolRegistry';
+import { EXECUTION_RESULT_EVENT, PLAN_CREATED_EVENT } from './events';
+
+interface ExecutorAgentDependencies {
+    eventBus?: EventBus;
+    sessionMemory: SessionMemory;
+    auditLog: AuditLogService;
+    toolRegistry: ToolRegistry;
+}
+
 /**
- * The ExecutorAgent is responsible for taking an approved execution plan
- * and running each step by calling the appropriate tools from the ToolRegistry.
+ * The ExecutorAgent executes each step of a plan by invoking the ToolRegistry
+ * and publishing the results back on the event bus.
  */
-export class ExecutorAgent {
-    // ...
+export class ExecutorAgent implements IAgent {
+    private readonly bus: EventBus;
+    private unsubscribe?: () => void;
+
+    constructor(private readonly deps: ExecutorAgentDependencies) {
+        this.bus = deps.eventBus ?? eventBus;
+    }
+
+    initialize(): void {
+        this.unsubscribe = this.bus.subscribe<ExecutionPlan>(PLAN_CREATED_EVENT, (plan) => {
+            void this.executePlan(plan);
+        });
+    }
+
+    dispose(): void {
+        this.unsubscribe?.();
+    }
+
+    private async executePlan(plan: ExecutionPlan): Promise<void> {
+        for (const step of plan.steps) {
+            const shouldContinue = await this.executeStep(plan.planId, step);
+            if (!shouldContinue) {
+                break;
+            }
+        }
+    }
+
+    private async executeStep(planId: string, step: ExecutionStep): Promise<boolean> {
+        try {
+            this.deps.auditLog.info('Executing plan step', { planId, step: step.step, toolId: step.toolId });
+            const result = await this.deps.toolRegistry.execute(step.toolId, step.args);
+            this.deps.sessionMemory.recordExecutionResult(planId, step, result);
+            this.bus.publish(EXECUTION_RESULT_EVENT, { planId, step, result });
+            return true;
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            this.deps.auditLog.error('Plan step failed', { planId, step: step.step, toolId: step.toolId, error: message });
+            this.deps.sessionMemory.recordExecutionResult(planId, step, undefined, message);
+            this.bus.publish(EXECUTION_RESULT_EVENT, { planId, step, error: message });
+            return false;
+        }
+    }
 }

--- a/blink-note-obsidian/src/agents/PlannerAgent.ts
+++ b/blink-note-obsidian/src/agents/PlannerAgent.ts
@@ -1,9 +1,157 @@
 // src/agents/PlannerAgent.ts
 
+import { eventBus, EventBus } from '../services/EventBus';
+import { SessionMemory } from '../services/SessionMemory';
+import { AuditLogService } from '../services/AuditLogService';
+import { ExecutionPlan, ToolManifest } from '../types';
+import { IAgent } from '../types/Agent';
+import { ToolRegistry } from '../tools/ToolRegistry';
+import { createId } from '../utils/id';
+import { PLAN_CREATED_EVENT, USER_COMMAND_EVENT, UserCommandPayload } from './events';
+
+interface PlannerAgentDependencies {
+    eventBus?: EventBus;
+    sessionMemory: SessionMemory;
+    auditLog: AuditLogService;
+    toolRegistry: ToolRegistry;
+}
+
 /**
  * The PlannerAgent is responsible for taking a user's command
- * and generating a step-by-step execution plan using an LLM.
+ * and generating a step-by-step execution plan using available tools.
  */
-export class PlannerAgent {
-    // ...
+export class PlannerAgent implements IAgent {
+    private readonly bus: EventBus;
+    private unsubscribe?: () => void;
+
+    constructor(private readonly deps: PlannerAgentDependencies) {
+        this.bus = deps.eventBus ?? eventBus;
+    }
+
+    initialize(): void {
+        this.unsubscribe = this.bus.subscribe<UserCommandPayload>(USER_COMMAND_EVENT, (payload) => {
+            void this.handleUserCommand(payload);
+        });
+    }
+
+    dispose(): void {
+        this.unsubscribe?.();
+    }
+
+    private async handleUserCommand(payload: UserCommandPayload): Promise<void> {
+        this.deps.sessionMemory.recordCommand(payload.command, payload.metadata);
+        this.deps.auditLog.info('Received user command', { command: payload.command });
+
+        const plan = this.buildPlan(payload.command, payload.metadata);
+        this.deps.sessionMemory.recordPlan(plan);
+        this.deps.auditLog.info('Generated execution plan', { planId: plan.planId, steps: plan.steps.length });
+
+        this.bus.publish(PLAN_CREATED_EVENT, plan);
+    }
+
+    private buildPlan(command: string, metadata?: Record<string, any>): ExecutionPlan {
+        const selectedTools = this.selectTools(command, metadata);
+        const steps = selectedTools.reduce<ExecutionPlan['steps']>((acc, tool) => {
+            const args = this.buildArgsForTool(tool.toolId, command, metadata);
+            if (args === null) {
+                return acc;
+            }
+            acc.push({
+                step: acc.length + 1,
+                toolId: tool.toolId,
+                args,
+                description: this.describeStep(tool, command),
+            });
+            return acc;
+        }, []);
+
+        return {
+            planId: createId('plan'),
+            userCommand: command,
+            steps,
+        };
+    }
+
+    private selectTools(command: string, metadata?: Record<string, any>): ToolManifest[] {
+        const manifest = this.deps.toolRegistry.getManifest();
+        const byId = new Map(manifest.map((tool) => [tool.toolId, tool]));
+        const selected: ToolManifest[] = [];
+        const lowerCommand = command.toLowerCase();
+
+        const maybeAdd = (toolId: string, condition: boolean = true) => {
+            if (!condition) {
+                return;
+            }
+            const tool = byId.get(toolId);
+            if (tool && !selected.includes(tool)) {
+                selected.push(tool);
+            }
+        };
+
+        maybeAdd('sync_get_status', /sync|synchronise|synchronize|upload|download/.test(lowerCommand));
+        maybeAdd('sync_queue_push', /upload|push/.test(lowerCommand));
+        maybeAdd('sync_queue_pull', /pull|download/.test(lowerCommand));
+
+        maybeAdd('clickup_create_task', /task|clickup|todo/.test(lowerCommand));
+        maybeAdd('clickup_get_task', Boolean(metadata?.taskId));
+
+        maybeAdd('context7_resolve_library_id', /doc|documentation|api|library/.test(lowerCommand));
+        maybeAdd('context7_get_library_docs', /doc|documentation|api|library/.test(lowerCommand));
+
+        maybeAdd('filesystem_find_file', /file|note|find|search/.test(lowerCommand));
+        maybeAdd('filesystem_read_file', Boolean(metadata?.path));
+        maybeAdd('filesystem_write_file', Boolean(metadata?.content) || /write|create/.test(lowerCommand));
+
+        if (selected.length === 0 && manifest.length > 0) {
+            selected.push(manifest[0]);
+        }
+
+        return selected;
+    }
+
+    private buildArgsForTool(toolId: string, command: string, metadata?: Record<string, any>): Record<string, any> | null {
+        switch (toolId) {
+            case 'sync_get_status':
+                return {};
+            case 'sync_queue_push':
+                return metadata?.path ? { path: metadata.path, hash: metadata.hash, remoteId: metadata.remoteId } : null;
+            case 'sync_queue_pull':
+                return { since: metadata?.since };
+            case 'clickup_create_task':
+                return {
+                    name: metadata?.taskName ?? command,
+                    description: metadata?.description,
+                    status: metadata?.status ?? 'todo',
+                };
+            case 'clickup_get_task':
+                return metadata?.taskId ? { id: metadata.taskId } : null;
+            case 'context7_resolve_library_id':
+                return { libraryName: metadata?.libraryName ?? command };
+            case 'context7_get_library_docs':
+                return {
+                    context7CompatibleLibraryID: metadata?.context7CompatibleLibraryID ?? '/mock/library/docs',
+                    topic: metadata?.topic,
+                    tokens: metadata?.tokens,
+                };
+            case 'filesystem_find_file':
+                return { query: metadata?.query ?? command, limit: metadata?.limit ?? 20 };
+            case 'filesystem_read_file':
+                return metadata?.path ? { path: metadata.path, encoding: metadata?.encoding ?? 'utf-8' } : null;
+            case 'filesystem_write_file':
+                if (!metadata?.path || typeof metadata.content !== 'string') {
+                    return null;
+                }
+                return {
+                    path: metadata.path,
+                    content: metadata.content,
+                    encoding: metadata?.encoding ?? 'utf-8',
+                };
+            default:
+                return metadata?.[toolId] ?? {};
+        }
+    }
+
+    private describeStep(tool: ToolManifest, command: string): string {
+        return tool.description || `Run ${tool.toolId} for command "${command}"`;
+    }
 }

--- a/blink-note-obsidian/src/agents/events.ts
+++ b/blink-note-obsidian/src/agents/events.ts
@@ -1,0 +1,21 @@
+// src/agents/events.ts
+
+import { ExecutionPlan, ExecutionStep } from '../types';
+
+export const USER_COMMAND_EVENT = 'blinknote:user-command';
+export const PLAN_CREATED_EVENT = 'blinknote:plan-created';
+export const EXECUTION_RESULT_EVENT = 'blinknote:execution-result';
+
+export interface UserCommandPayload {
+    command: string;
+    metadata?: Record<string, any>;
+}
+
+export type PlanCreatedPayload = ExecutionPlan;
+
+export interface ExecutionResultPayload {
+    planId: string;
+    step: ExecutionStep;
+    result?: unknown;
+    error?: string;
+}

--- a/blink-note-obsidian/src/agents/index.ts
+++ b/blink-note-obsidian/src/agents/index.ts
@@ -1,11 +1,57 @@
 // src/agents/index.ts
 
+import { eventBus } from '../services/EventBus';
+import { auditLogService, AuditLogService } from '../services/AuditLogService';
+import { sessionMemory, SessionMemory } from '../services/SessionMemory';
+import { PlannerAgent } from './PlannerAgent';
+import { ExecutorAgent } from './ExecutorAgent';
+import { ToolRegistry } from '../tools/ToolRegistry';
+
 export * from './PlannerAgent';
 export * from './ExecutorAgent';
+export * from './events';
+
+export interface InitializeAgentsOptions {
+    toolRegistry: ToolRegistry;
+    sessionMemory?: SessionMemory;
+    auditLog?: AuditLogService;
+}
+
+export interface InitializedAgents {
+    planner: PlannerAgent;
+    executor: ExecutorAgent;
+    dispose(): void;
+}
 
 /**
  * Initializes all agents and subscribes them to the event bus.
  */
-export function initializeAgents() {
-    // This function will be called from main.ts
+export function initializeAgents(options: InitializeAgentsOptions): InitializedAgents {
+    const memory = options.sessionMemory ?? sessionMemory;
+    const auditLog = options.auditLog ?? auditLogService;
+
+    const planner = new PlannerAgent({
+        eventBus,
+        sessionMemory: memory,
+        auditLog,
+        toolRegistry: options.toolRegistry,
+    });
+    const executor = new ExecutorAgent({
+        eventBus,
+        sessionMemory: memory,
+        auditLog,
+        toolRegistry: options.toolRegistry,
+    });
+
+    planner.initialize();
+    executor.initialize();
+
+    return {
+        planner,
+        executor,
+        dispose() {
+            planner.dispose();
+            executor.dispose();
+        },
+    };
 }

--- a/blink-note-obsidian/src/main.ts
+++ b/blink-note-obsidian/src/main.ts
@@ -2,23 +2,23 @@
 
 import { Plugin } from 'obsidian';
 import { eventBus } from './services/EventBus';
-// import { BlinkNoteView, VIEW_TYPE_BLINK_NOTE } from './ui/BlinkNoteView';
-// import { SettingTab } from './settings/SettingTab';
-import { initializeAgents } from './agents';
+import { initializeAgents, InitializedAgents } from './agents';
 import { ToolRegistry } from './tools/ToolRegistry';
 import { FilesystemProvider } from './tools/providers/FilesystemProvider';
 import { ClickUpProvider } from './tools/providers/ClickUpProvider';
 import { Context7Provider } from './tools/providers/Context7Provider';
+import { SyncProvider } from './tools/providers/SyncProvider';
 
 export default class BlinkNotePlugin extends Plugin {
     toolRegistry: ToolRegistry;
+    private agents?: InitializedAgents;
 
     async onload() {
         console.log('Blink Note Plugin: Loading...');
 
         // 1. Initialize Core Services & Agents
         this.initializeTools();
-        initializeAgents();
+        this.agents = initializeAgents({ toolRegistry: this.toolRegistry });
 
         // 2. Register the custom view for our UI
         // this.registerView(
@@ -47,6 +47,7 @@ export default class BlinkNotePlugin extends Plugin {
 
     async onunload() {
         console.log('Blink Note Plugin: Unloading...');
+        this.agents?.dispose();
     }
 
     initializeTools(): void {
@@ -56,6 +57,7 @@ export default class BlinkNotePlugin extends Plugin {
         this.toolRegistry.register(new FilesystemProvider());
         this.toolRegistry.register(new ClickUpProvider());
         this.toolRegistry.register(new Context7Provider()); // <-- User-requested provider
+        this.toolRegistry.register(new SyncProvider());
 
         console.log('Tool providers registered.');
     }

--- a/blink-note-obsidian/src/services/AuditLogService.ts
+++ b/blink-note-obsidian/src/services/AuditLogService.ts
@@ -1,9 +1,59 @@
 // src/services/AuditLogService.ts
 
+import { createId } from '../utils/id';
+
+export type AuditLogLevel = 'info' | 'warn' | 'error';
+
+export interface AuditLogEntry {
+    id: string;
+    timestamp: number;
+    level: AuditLogLevel;
+    message: string;
+    context?: Record<string, unknown>;
+}
+
 /**
  * Provides a persistent, append-only log of all actions taken by the agents.
  * This is critical for transparency and debugging.
  */
 export class AuditLogService {
-    // ...
+    private entries: AuditLogEntry[] = [];
+
+    log(level: AuditLogLevel, message: string, context?: Record<string, unknown>): AuditLogEntry {
+        const entry: AuditLogEntry = {
+            id: createId('audit'),
+            timestamp: Date.now(),
+            level,
+            message,
+            context,
+        };
+        this.entries.push(entry);
+        return entry;
+    }
+
+    info(message: string, context?: Record<string, unknown>): AuditLogEntry {
+        return this.log('info', message, context);
+    }
+
+    warn(message: string, context?: Record<string, unknown>): AuditLogEntry {
+        return this.log('warn', message, context);
+    }
+
+    error(message: string, context?: Record<string, unknown>): AuditLogEntry {
+        return this.log('error', message, context);
+    }
+
+    getEntries(): ReadonlyArray<AuditLogEntry> {
+        return this.entries;
+    }
+
+    getRecent(count: number): AuditLogEntry[] {
+        return this.entries.slice(-count);
+    }
+
+    clear(): void {
+        this.entries = [];
+    }
 }
+
+export const auditLogService = new AuditLogService();

--- a/blink-note-obsidian/src/services/IndexStore.ts
+++ b/blink-note-obsidian/src/services/IndexStore.ts
@@ -1,10 +1,93 @@
 // src/services/IndexStore.ts
 
+import { FileMeta, FilePath } from '../types';
+
+export interface IndexDiff {
+    added: FileMeta[];
+    removed: FileMeta[];
+    updated: FileMeta[];
+}
+
 /**
  * Manages the persistent index of file metadata, including hashes and sync status.
  * This is crucial for determining which files have changed and need to be synced.
  */
-// Full implementation will follow the details in Overview-2.md
 export class IndexStore {
-    // ...
+    private index: Map<FilePath, FileMeta> = new Map();
+
+    load(entries: Iterable<FileMeta>): void {
+        for (const entry of entries) {
+            this.upsert(entry);
+        }
+    }
+
+    upsert(meta: FileMeta): void {
+        this.index.set(meta.path, { ...this.index.get(meta.path), ...meta });
+    }
+
+    remove(path: FilePath): void {
+        this.index.delete(path);
+    }
+
+    get(path: FilePath): FileMeta | undefined {
+        return this.index.get(path);
+    }
+
+    list(): FileMeta[] {
+        return Array.from(this.index.values());
+    }
+
+    has(path: FilePath): boolean {
+        return this.index.has(path);
+    }
+
+    clear(): void {
+        this.index.clear();
+    }
+
+    toJSON(): FileMeta[] {
+        return this.list();
+    }
+
+    /**
+     * Compares the in-memory index with a snapshot (e.g., from disk or remote)
+     * and returns a diff representing added, removed, and updated entries.
+     */
+    diffAgainst(snapshot: Iterable<FileMeta>): IndexDiff {
+        const added: FileMeta[] = [];
+        const removed: FileMeta[] = [];
+        const updated: FileMeta[] = [];
+        const snapshotMap = new Map<FilePath, FileMeta>();
+
+        for (const entry of snapshot) {
+            snapshotMap.set(entry.path, entry);
+        }
+
+        for (const [path, meta] of this.index.entries()) {
+            const snapshotMeta = snapshotMap.get(path);
+            if (!snapshotMeta) {
+                added.push(meta);
+            } else if (this.isMetaDifferent(meta, snapshotMeta)) {
+                updated.push(meta);
+            }
+            snapshotMap.delete(path);
+        }
+
+        for (const remaining of snapshotMap.values()) {
+            removed.push(remaining);
+        }
+
+        return { added, removed, updated };
+    }
+
+    private isMetaDifferent(a: FileMeta, b: FileMeta): boolean {
+        return (
+            a.size !== b.size ||
+            a.etag !== b.etag ||
+            a.lastModified !== b.lastModified ||
+            a.remoteId !== b.remoteId
+        );
+    }
 }
+
+export const indexStore = new IndexStore();

--- a/blink-note-obsidian/src/services/SessionMemory.ts
+++ b/blink-note-obsidian/src/services/SessionMemory.ts
@@ -1,9 +1,93 @@
 // src/services/SessionMemory.ts
 
+import { ExecutionPlan, ExecutionStep } from '../types';
+import { createId } from '../utils/id';
+
+export type SessionEntry =
+    | {
+          type: 'command';
+          id: string;
+          timestamp: number;
+          command: string;
+          metadata?: Record<string, any>;
+      }
+    | {
+          type: 'plan';
+          id: string;
+          timestamp: number;
+          plan: ExecutionPlan;
+      }
+    | {
+          type: 'execution';
+          id: string;
+          timestamp: number;
+          planId: string;
+          step: ExecutionStep;
+          result?: unknown;
+          error?: string;
+      };
+
 /**
  * Stores the history of the current user session, including commands,
  * plans, and execution results. This provides context for the PlannerAgent.
  */
 export class SessionMemory {
-    // ...
+    private history: SessionEntry[] = [];
+
+    recordCommand(command: string, metadata?: Record<string, any>): SessionEntry {
+        const entry: SessionEntry = {
+            type: 'command',
+            id: createId('command'),
+            timestamp: Date.now(),
+            command,
+            metadata,
+        };
+        this.history.push(entry);
+        return entry;
+    }
+
+    recordPlan(plan: ExecutionPlan): SessionEntry {
+        const entry: SessionEntry = {
+            type: 'plan',
+            id: createId('plan'),
+            timestamp: Date.now(),
+            plan,
+        };
+        this.history.push(entry);
+        return entry;
+    }
+
+    recordExecutionResult(planId: string, step: ExecutionStep, result?: unknown, error?: string): SessionEntry {
+        const entry: SessionEntry = {
+            type: 'execution',
+            id: createId('exec'),
+            timestamp: Date.now(),
+            planId,
+            step,
+            result,
+            error,
+        };
+        this.history.push(entry);
+        return entry;
+    }
+
+    getHistory(): ReadonlyArray<SessionEntry> {
+        return this.history;
+    }
+
+    getLastPlan(): ExecutionPlan | undefined {
+        for (let i = this.history.length - 1; i >= 0; i--) {
+            const entry = this.history[i];
+            if (entry.type === 'plan') {
+                return entry.plan;
+            }
+        }
+        return undefined;
+    }
+
+    clear(): void {
+        this.history = [];
+    }
 }
+
+export const sessionMemory = new SessionMemory();

--- a/blink-note-obsidian/src/tools/ToolRegistry.ts
+++ b/blink-note-obsidian/src/tools/ToolRegistry.ts
@@ -1,10 +1,70 @@
 // src/tools/ToolRegistry.ts
 
+import { IToolProvider, ToolManifest } from '../types';
+
+interface RegisteredTool {
+    manifest: ToolManifest;
+    provider: IToolProvider;
+}
+
 /**
  * A central registry for all available tools from all providers.
  * The PlannerAgent uses this to get a manifest of available tools,
  * and the ExecutorAgent uses this to execute a specific tool.
  */
 export class ToolRegistry {
-    // ...
+    private providers = new Set<IToolProvider>();
+    private tools = new Map<string, RegisteredTool>();
+
+    register(provider: IToolProvider): void {
+        if (this.providers.has(provider)) {
+            return;
+        }
+
+        const manifest = provider.getManifest();
+        manifest.forEach((tool) => {
+            if (this.tools.has(tool.toolId)) {
+                throw new Error(`Tool with id "${tool.toolId}" is already registered.`);
+            }
+            this.tools.set(tool.toolId, { manifest: tool, provider });
+        });
+
+        this.providers.add(provider);
+    }
+
+    unregister(provider: IToolProvider): void {
+        if (!this.providers.delete(provider)) {
+            return;
+        }
+
+        for (const [toolId, entry] of Array.from(this.tools.entries())) {
+            if (entry.provider === provider) {
+                this.tools.delete(toolId);
+            }
+        }
+    }
+
+    hasTool(toolId: string): boolean {
+        return this.tools.has(toolId);
+    }
+
+    getManifest(): ToolManifest[] {
+        return Array.from(this.tools.values()).map((entry) => entry.manifest);
+    }
+
+    getTool(toolId: string): ToolManifest | undefined {
+        return this.tools.get(toolId)?.manifest;
+    }
+
+    listProviders(): IToolProvider[] {
+        return Array.from(this.providers);
+    }
+
+    async execute(toolId: string, args: Record<string, any>): Promise<any> {
+        const entry = this.tools.get(toolId);
+        if (!entry) {
+            throw new Error(`Tool "${toolId}" is not registered.`);
+        }
+        return entry.provider.execute(toolId, args);
+    }
 }

--- a/blink-note-obsidian/src/tools/providers/ClickUpProvider.ts
+++ b/blink-note-obsidian/src/tools/providers/ClickUpProvider.ts
@@ -1,8 +1,85 @@
 // src/tools/providers/ClickUpProvider.ts
 
+import { IToolProvider, ToolManifest } from '../../types';
+import { createId } from '../../utils/id';
+
+interface ClickUpTask {
+    id: string;
+    name: string;
+    description?: string;
+    status: 'todo' | 'in_progress' | 'done';
+    url: string;
+    createdAt: number;
+    customFields?: Record<string, any>;
+}
+
 /**
  * Provides tools for interacting with the ClickUp API.
+ * The current implementation keeps an in-memory task list which is sufficient
+ * for local development and automated testing.
  */
-export class ClickUpProvider {
-    // e.g., create_task, get_task_details
+export class ClickUpProvider implements IToolProvider {
+    private tasks = new Map<string, ClickUpTask>();
+
+    constructor(private readonly workspaceSlug: string = 'workspace') {}
+
+    getManifest(): ToolManifest[] {
+        return [
+            {
+                toolId: 'clickup_create_task',
+                description: 'Creates a lightweight task in the in-memory ClickUp store.',
+                argsSchema: {
+                    name: { type: 'string', description: 'Title of the task to create.', required: true },
+                    description: { type: 'string', description: 'Optional task description.' },
+                    status: { type: 'string', description: 'Task status (todo, in_progress, done).' },
+                },
+            },
+            {
+                toolId: 'clickup_get_task',
+                description: 'Retrieves a task by id from the in-memory ClickUp store.',
+                argsSchema: {
+                    id: { type: 'string', description: 'Identifier of the task to fetch.', required: true },
+                },
+            },
+        ];
+    }
+
+    async execute(toolId: string, args: Record<string, any>): Promise<any> {
+        switch (toolId) {
+            case 'clickup_create_task':
+                return this.createTask(String(args.name), args.description ? String(args.description) : undefined, args.status ? String(args.status) : 'todo');
+            case 'clickup_get_task':
+                return this.getTask(String(args.id));
+            default:
+                throw new Error(`Tool "${toolId}" not found in ClickUpProvider.`);
+        }
+    }
+
+    private createTask(name: string, description?: string, status: string = 'todo'): ClickUpTask {
+        if (!name) {
+            throw new Error('clickup_create_task requires a "name" argument.');
+        }
+        if (!['todo', 'in_progress', 'done'].includes(status)) {
+            throw new Error('Invalid status. Expected one of todo, in_progress, done.');
+        }
+        const id = createId('task');
+        const task: ClickUpTask = {
+            id,
+            name,
+            description,
+            status: status as ClickUpTask['status'],
+            url: `https://app.clickup.com/${this.workspaceSlug}/task/${id}`,
+            createdAt: Date.now(),
+        };
+        this.tasks.set(id, task);
+        return task;
+    }
+
+    private getTask(id: string): ClickUpTask {
+        const task = this.tasks.get(id);
+        if (!task) {
+            throw new Error(`Task with id "${id}" was not found.`);
+        }
+        return task;
+    }
 }

--- a/blink-note-obsidian/src/tools/providers/Context7Provider.ts
+++ b/blink-note-obsidian/src/tools/providers/Context7Provider.ts
@@ -1,17 +1,16 @@
 // src/tools/providers/Context7Provider.ts
 
-// import { IToolProvider, ToolManifest } from '../../types/Tool';
+import { IToolProvider, ToolManifest } from '../../types';
 
 /**
  * Provides tools for interacting with the Context7 MCP server.
  * This allows the agent to fetch up-to-date documentation and code examples for any library.
  */
-export class Context7Provider /* implements IToolProvider */ {
-
+export class Context7Provider implements IToolProvider {
     // In a real implementation, this would be injected or configured.
     private mcpServerUrl = 'http://localhost:3000';
 
-    getManifest() /* : ToolManifest[] */ {
+    getManifest(): ToolManifest[] {
         return [
             {
                 toolId: 'context7_resolve_library_id',
@@ -42,7 +41,7 @@ export class Context7Provider /* implements IToolProvider */ {
                         type: 'number',
                         description: 'Max number of tokens to return (default 5000)',
                         required: false,
-                    }
+                    },
                 },
             },
         ];
@@ -53,13 +52,14 @@ export class Context7Provider /* implements IToolProvider */ {
             case 'context7_resolve_library_id':
                 // Mock implementation:
                 console.log(`[Context7Provider] Resolving library ID for: ${args.libraryName}`);
-                return { libraryId: `/mock/${args.libraryName.toLowerCase()}/docs` };
+                return { libraryId: `/mock/${String(args.libraryName ?? '').toLowerCase()}/docs` };
 
             case 'context7_get_library_docs':
                 // Mock implementation:
                 console.log(`[Context7Provider] Getting docs for: ${args.context7CompatibleLibraryID} on topic "${args.topic}"`);
                 return {
                     docs: `// Mock documentation for ${args.context7CompatibleLibraryID}\n// Topic: ${args.topic || 'general'}\n\nfunction helloWorld() {\n  console.log("Hello from mock docs!");\n}`,
+                    source: this.mcpServerUrl,
                 };
 
             default:

--- a/blink-note-obsidian/src/tools/providers/FilesystemProvider.ts
+++ b/blink-note-obsidian/src/tools/providers/FilesystemProvider.ts
@@ -1,8 +1,115 @@
 // src/tools/providers/FilesystemProvider.ts
 
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { IToolProvider, ToolManifest } from '../../types';
+
+interface FindFileResult {
+    path: string;
+    size: number;
+    lastModified: number;
+}
+
 /**
  * Provides tools for interacting with the local filesystem within the Obsidian vault.
  */
-export class FilesystemProvider {
-    // e.g., find_file, read_file, write_file
+export class FilesystemProvider implements IToolProvider {
+    constructor(private readonly root: string = process.cwd()) {}
+
+    getManifest(): ToolManifest[] {
+        return [
+            {
+                toolId: 'filesystem_find_file',
+                description: 'Searches the workspace for files matching the provided substring.',
+                argsSchema: {
+                    query: { type: 'string', description: 'Case-insensitive substring to match.', required: true },
+                    limit: { type: 'number', description: 'Maximum results to return (default 20).' },
+                },
+            },
+            {
+                toolId: 'filesystem_read_file',
+                description: 'Reads a UTF-8 encoded text file from the workspace.',
+                argsSchema: {
+                    path: { type: 'string', description: 'Path to the file relative to the workspace root.', required: true },
+                    encoding: { type: 'string', description: 'File encoding. Defaults to utf-8.' },
+                },
+            },
+            {
+                toolId: 'filesystem_write_file',
+                description: 'Writes text content to a file, creating directories if necessary.',
+                argsSchema: {
+                    path: { type: 'string', description: 'Target file path relative to the workspace root.', required: true },
+                    content: { type: 'string', description: 'Content to write to the file.', required: true },
+                    encoding: { type: 'string', description: 'File encoding. Defaults to utf-8.' },
+                },
+            },
+        ];
+    }
+
+    async execute(toolId: string, args: Record<string, any>): Promise<any> {
+        switch (toolId) {
+            case 'filesystem_find_file':
+                return this.findFiles(String(args.query ?? ''), Number(args.limit ?? 20));
+            case 'filesystem_read_file':
+                return this.readFile(String(args.path), args.encoding ? String(args.encoding) : 'utf-8');
+            case 'filesystem_write_file':
+                return this.writeFile(String(args.path), String(args.content ?? ''), args.encoding ? String(args.encoding) : 'utf-8');
+            default:
+                throw new Error(`Tool "${toolId}" not found in FilesystemProvider.`);
+        }
+    }
+
+    private resolvePath(relativePath: string): string {
+        if (!relativePath || relativePath.includes('..')) {
+            throw new Error('Invalid relative path.');
+        }
+        const resolved = path.resolve(this.root, relativePath);
+        if (!resolved.startsWith(path.resolve(this.root))) {
+            throw new Error('Attempted to access a path outside the workspace root.');
+        }
+        return resolved;
+    }
+
+    private async findFiles(query: string, limit: number): Promise<FindFileResult[]> {
+        if (!query) {
+            return [];
+        }
+        const results: FindFileResult[] = [];
+        await this.walkDirectory(this.root, async (filePath: string, stats: { size: number; mtimeMs: number }) => {
+            if (results.length >= limit) {
+                return;
+            }
+            const relative = path.relative(this.root, filePath);
+            if (relative.toLowerCase().includes(query.toLowerCase())) {
+                results.push({ path: relative, size: stats.size, lastModified: Math.round(stats.mtimeMs) });
+            }
+        });
+        return results;
+    }
+
+    private async readFile(relativePath: string, encoding: BufferEncoding): Promise<{ path: string; content: string }>{
+        const filePath = this.resolvePath(relativePath);
+        const content = await fs.readFile(filePath, { encoding });
+        return { path: relativePath, content };
+    }
+
+    private async writeFile(relativePath: string, content: string, encoding: BufferEncoding): Promise<{ path: string; bytesWritten: number }>{
+        const filePath = this.resolvePath(relativePath);
+        await fs.mkdir(path.dirname(filePath), { recursive: true });
+        await fs.writeFile(filePath, content, { encoding });
+        return { path: relativePath, bytesWritten: Buffer.byteLength(content, encoding) };
+    }
+
+    private async walkDirectory(dir: string, onFile: (filePath: string, stats: { size: number; mtimeMs: number }) => Promise<void>): Promise<void> {
+        const entries = await fs.readdir(dir, { withFileTypes: true });
+        for (const entry of entries) {
+            const fullPath = path.join(dir, entry.name);
+            if (entry.isDirectory()) {
+                await this.walkDirectory(fullPath, onFile);
+            } else if (entry.isFile()) {
+                const stats = await fs.stat(fullPath);
+                await onFile(fullPath, { size: stats.size, mtimeMs: stats.mtimeMs });
+            }
+        }
+    }
 }

--- a/blink-note-obsidian/src/tools/providers/S3Adapter.ts
+++ b/blink-note-obsidian/src/tools/providers/S3Adapter.ts
@@ -1,20 +1,52 @@
 // src/tools/providers/S3Adapter.ts
 
+import { createId } from '../../utils/id';
 import { RemoteAdapter } from './RemoteAdapter';
+
+interface S3ObjectEntry {
+    key: string;
+    content: string;
+    etag: string;
+    lastModified: number;
+}
 
 /**
  * An implementation of the RemoteAdapter for interacting with an S3-compatible object storage.
+ * This adapter keeps an in-memory representation that mimics the behaviour of S3 which makes it
+ * suitable for unit tests without requiring network credentials.
  */
-// Full implementation will follow the details in Overview-2.md
 export class S3Adapter implements RemoteAdapter {
-    pull(since: string): Promise<any> {
-        throw new Error('Method not implemented.');
+    private objects = new Map<string, S3ObjectEntry>();
+
+    constructor(private readonly bucket: string = 'blink-note') {}
+
+    async pull(since: string): Promise<S3ObjectEntry[]> {
+        const sinceTime = since ? new Date(since).getTime() : 0;
+        return Array.from(this.objects.values()).filter((object) => object.lastModified > sinceTime);
     }
-    push(change: any): Promise<any> {
-        throw new Error('Method not implemented.');
+
+    async push(change: any): Promise<S3ObjectEntry | { deleted: boolean; key: string }> {
+        const key = String(change.path ?? change.key ?? '');
+        if (!key) {
+            throw new Error('S3Adapter.push requires a "path" or "key" property.');
+        }
+        if (change.op === 'del') {
+            this.objects.delete(key);
+            return { deleted: true, key };
+        }
+
+        const content = typeof change.content === 'string' ? change.content : JSON.stringify(change.content ?? {});
+        const entry: S3ObjectEntry = {
+            key,
+            content,
+            etag: createId('etag'),
+            lastModified: Date.now(),
+        };
+        this.objects.set(key, entry);
+        return entry;
     }
-    stat(pathOrId: string): Promise<any | null> {
-        throw new Error('Method not implemented.');
+
+    async stat(pathOrId: string): Promise<S3ObjectEntry | null> {
+        return this.objects.get(pathOrId) ?? null;
     }
-    // ...
 }

--- a/blink-note-obsidian/src/tools/providers/SyncProvider.ts
+++ b/blink-note-obsidian/src/tools/providers/SyncProvider.ts
@@ -1,10 +1,155 @@
 // src/tools/providers/SyncProvider.ts
 
+import { indexStore, IndexStore } from '../../services/IndexStore';
+import { auditLogService } from '../../services/AuditLogService';
+import { Job, SyncStatus } from '../../types';
+import { IToolProvider, ToolManifest } from '../../types';
+import { createId } from '../../utils/id';
+import { RemoteAdapter } from './RemoteAdapter';
+
+interface QueueItem extends Job {
+    id: string;
+    status: 'queued' | 'running' | 'completed' | 'failed';
+    error?: string;
+}
+
 /**
  * Provides synchronization-related tools to the agentic system,
  * allowing the AI to trigger push, pull, and status check operations.
  */
-// Full implementation will follow the details in Overview-2.md
-export class SyncProvider {
-    // ...
+export class SyncProvider implements IToolProvider {
+    private queue: QueueItem[] = [];
+    private running = false;
+    private lastSyncedAt?: number;
+
+    constructor(private readonly store: IndexStore = indexStore, private readonly adapter?: RemoteAdapter) {}
+
+    getManifest(): ToolManifest[] {
+        return [
+            {
+                toolId: 'sync_get_status',
+                description: 'Returns the status of the synchronization queue.',
+                argsSchema: {},
+            },
+            {
+                toolId: 'sync_queue_push',
+                description: 'Queues a file to be pushed to the remote adapter.',
+                argsSchema: {
+                    path: { type: 'string', description: 'Path of the file to upload.', required: true },
+                    hash: { type: 'string', description: 'Content hash used for conflict detection.', required: false },
+                    remoteId: { type: 'string', description: 'Existing remote identifier, if known.' },
+                },
+            },
+            {
+                toolId: 'sync_queue_pull',
+                description: 'Fetches remote changes newer than the provided ISO timestamp.',
+                argsSchema: {
+                    since: { type: 'string', description: 'ISO timestamp. Defaults to last sync time.' },
+                },
+            },
+        ];
+    }
+
+    async execute(toolId: string, args: Record<string, any>): Promise<any> {
+        switch (toolId) {
+            case 'sync_get_status':
+                return this.getStatus();
+            case 'sync_queue_push':
+                return this.enqueuePush(args.path, args.hash, args.remoteId);
+            case 'sync_queue_pull':
+                return this.pullRemoteChanges(args.since);
+            default:
+                throw new Error(`Tool "${toolId}" not found in SyncProvider.`);
+        }
+    }
+
+    private getStatus(): SyncStatus {
+        return {
+            queued: this.queue.filter((item) => item.status === 'queued' || item.status === 'running').length,
+            running: this.running,
+            lastSyncedAt: this.lastSyncedAt,
+        };
+    }
+
+    private async enqueuePush(path: string, hash?: string, remoteId?: string): Promise<{ job: QueueItem; status: SyncStatus }> {
+        if (!path) {
+            throw new Error('sync_queue_push requires a "path" argument.');
+        }
+
+        const job: QueueItem = {
+            id: createId('job'),
+            op: 'up',
+            path,
+            hash,
+            remoteId,
+            status: 'queued',
+        };
+
+        this.queue.push(job);
+        this.processQueue().catch((error) => {
+            auditLogService.error('Failed processing sync queue', { error: String(error) });
+        });
+
+        return { job, status: this.getStatus() };
+    }
+
+    private async pullRemoteChanges(since?: string): Promise<{ changes: any[]; status: SyncStatus }> {
+        const effectiveSince = since ?? (this.lastSyncedAt ? new Date(this.lastSyncedAt).toISOString() : new Date(0).toISOString());
+        const changes = this.adapter ? await this.adapter.pull(effectiveSince) : [];
+        if (changes.length > 0) {
+            this.lastSyncedAt = Date.now();
+        }
+        return { changes, status: this.getStatus() };
+    }
+
+    private async processQueue(): Promise<void> {
+        if (this.running) {
+            return;
+        }
+        this.running = true;
+
+        try {
+            for (const item of this.queue) {
+                if (item.status !== 'queued') {
+                    continue;
+                }
+                item.status = 'running';
+                try {
+                    await this.processJob(item);
+                    item.status = 'completed';
+                } catch (error) {
+                    item.status = 'failed';
+                    item.error = error instanceof Error ? error.message : String(error);
+                    auditLogService.error('Sync job failed', { jobId: item.id, error: item.error });
+                }
+            }
+        } finally {
+            this.running = false;
+            this.lastSyncedAt = Date.now();
+            this.queue = this.queue.filter((item) => item.status !== 'completed');
+        }
+    }
+
+    private async processJob(job: QueueItem): Promise<void> {
+        if (job.op === 'up') {
+            const meta = this.store.get(job.path);
+            const payload = {
+                path: job.path,
+                hash: job.hash ?? meta?.etag ?? meta?.remoteId,
+                remoteId: job.remoteId ?? meta?.remoteId,
+            };
+            if (this.adapter) {
+                await this.adapter.push(payload);
+            }
+        } else if (job.op === 'down') {
+            if (this.adapter) {
+                await this.adapter.pull(new Date(this.lastSyncedAt ?? 0).toISOString());
+            }
+        } else if (job.op === 'del') {
+            if (this.adapter) {
+                await this.adapter.push({ path: job.path, op: 'del' });
+            }
+            this.store.remove(job.path);
+        }
+    }
 }

--- a/blink-note-obsidian/src/tools/providers/WebDAVAdapter.ts
+++ b/blink-note-obsidian/src/tools/providers/WebDAVAdapter.ts
@@ -1,20 +1,52 @@
 // src/tools/providers/WebDAVAdapter.ts
 
+import { createId } from '../../utils/id';
 import { RemoteAdapter } from './RemoteAdapter';
+
+interface WebDavResource {
+    path: string;
+    content: string;
+    etag: string;
+    lastModified: number;
+}
 
 /**
  * An implementation of the RemoteAdapter for interacting with a WebDAV server.
+ * Uses an in-memory representation which mirrors WebDAV semantics closely enough
+ * for local development.
  */
-// Full implementation will follow the details in Overview-2.md
 export class WebDAVAdapter implements RemoteAdapter {
-    pull(since: string): Promise<any> {
-        throw new Error('Method not implemented.');
+    private resources = new Map<string, WebDavResource>();
+
+    constructor(private readonly endpoint: string = 'https://webdav.local') {}
+
+    async pull(since: string): Promise<WebDavResource[]> {
+        const sinceTime = since ? new Date(since).getTime() : 0;
+        return Array.from(this.resources.values()).filter((resource) => resource.lastModified > sinceTime);
     }
-    push(change: any): Promise<any> {
-        throw new Error('Method not implemented.');
+
+    async push(change: any): Promise<WebDavResource | { deleted: boolean; path: string }> {
+        const resourcePath = String(change.path ?? '');
+        if (!resourcePath) {
+            throw new Error('WebDAVAdapter.push requires a "path" property.');
+        }
+        if (change.op === 'del') {
+            this.resources.delete(resourcePath);
+            return { deleted: true, path: resourcePath };
+        }
+
+        const content = typeof change.content === 'string' ? change.content : JSON.stringify(change.content ?? {});
+        const entry: WebDavResource = {
+            path: resourcePath,
+            content,
+            etag: createId('etag'),
+            lastModified: Date.now(),
+        };
+        this.resources.set(resourcePath, entry);
+        return entry;
     }
-    stat(pathOrId: string): Promise<any | null> {
-        throw new Error('Method not implemented.');
+
+    async stat(pathOrId: string): Promise<WebDavResource | null> {
+        return this.resources.get(pathOrId) ?? null;
     }
-    // ...
 }

--- a/blink-note-obsidian/src/types/Agent.ts
+++ b/blink-note-obsidian/src/types/Agent.ts
@@ -6,4 +6,7 @@
 export interface IAgent {
     // Method to initialize the agent, subscribing to relevant events.
     initialize(): void;
+
+    // Optional method to clean up resources.
+    dispose?(): void;
 }

--- a/blink-note-obsidian/src/utils/id.ts
+++ b/blink-note-obsidian/src/utils/id.ts
@@ -1,0 +1,21 @@
+const FALLBACK_RANDOM_CHARS = 8;
+
+function randomString(): string {
+    return Math.random().toString(36).slice(2, 2 + FALLBACK_RANDOM_CHARS);
+}
+
+/**
+ * Generates a reasonably unique identifier that is stable across runtimes
+ * without requiring external dependencies. When available it uses
+ * `crypto.randomUUID` for high quality randomness and falls back to a
+ * timestamp-based id.
+ */
+export function createId(prefix: string): string {
+    const cryptoApi = (globalThis as typeof globalThis & { crypto?: Crypto }).crypto;
+    if (cryptoApi && typeof cryptoApi.randomUUID === 'function') {
+        return `${prefix}-${cryptoApi.randomUUID()}`;
+    }
+
+    const timestamp = Date.now().toString(36);
+    return `${prefix}-${timestamp}-${randomString()}`;
+}


### PR DESCRIPTION
## Summary
- wire the plugin startup to register the tool registry, bootstrap planner/executor agents, and expose the new sync provider
- implement planner/executor agents plus shared event contracts backed by session memory, audit logging, and an expanded tool registry
- flesh out filesystem, ClickUp, Context7, sync, and remote adapters as concrete tool providers and add a shared ID utility

## Testing
- npm install *(fails: registry returned 403 Forbidden for @types/node)*

------
https://chatgpt.com/codex/tasks/task_e_68ca8eaa1304832f8c9604a2085c0db9